### PR TITLE
Add FlagGrid component with placeholder data

### DIFF
--- a/__tests__/FlagGrid.test.jsx
+++ b/__tests__/FlagGrid.test.jsx
@@ -1,0 +1,11 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import FlagGrid from "../src/components/FlagGrid";
+
+test("renders a card for each placeholder flag", () => {
+  render(<FlagGrid />);
+  const cards = screen.getAllByText(
+    /^(Rainbow|Transgender|Bisexual|Asexual|Pansexual|Non-binary)$/,
+  );
+  expect(cards).toHaveLength(6);
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', {targets: {node: 'current'}}],
-    ['@babel/preset-react', {runtime: 'automatic'}],
+    ["@babel/preset-env", { targets: { node: "current" } }],
+    ["@babel/preset-react", { runtime: "automatic" }],
+    "@babel/preset-typescript",
   ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@babel/core": "^7.24.5",
         "@babel/preset-env": "^7.24.5",
         "@babel/preset-react": "^7.24.5",
+        "@babel/preset-typescript": "^7.24.5",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^14.3.0",
         "@typescript-eslint/eslint-plugin": "^8.34.1",
@@ -1611,6 +1612,26 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-transform-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
+      "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.27.1",
+        "@babel/helper-create-class-features-plugin": "^7.27.1",
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+        "@babel/plugin-syntax-typescript": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
@@ -1790,6 +1811,26 @@
         "@babel/plugin-transform-react-jsx": "^7.27.1",
         "@babel/plugin-transform-react-jsx-development": "^7.27.1",
         "@babel/plugin-transform-react-pure-annotations": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-typescript": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+      "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/plugin-syntax-jsx": "^7.27.1",
+        "@babel/plugin-transform-modules-commonjs": "^7.27.1",
+        "@babel/plugin-transform-typescript": "^7.27.1"
       },
       "engines": {
         "node": ">=6.9.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@babel/core": "^7.24.5",
     "@babel/preset-env": "^7.24.5",
     "@babel/preset-react": "^7.24.5",
+    "@babel/preset-typescript": "^7.24.5",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^14.3.0",
     "@typescript-eslint/eslint-plugin": "^8.34.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React from "react";
+import FlagGrid from "./components/FlagGrid";
 
 function App() {
   return (
@@ -7,7 +8,7 @@ function App() {
         <h1 className="text-center text-2xl font-bold">Patchwork Pride</h1>
       </header>
       <main className="p-4">
-        <p className="text-gray-700">Content coming soon.</p>
+        <FlagGrid />
       </main>
     </div>
   );

--- a/src/components/FlagCard.tsx
+++ b/src/components/FlagCard.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+
+interface FlagCardProps {
+  name: string;
+}
+
+function FlagCard({ name }: FlagCardProps) {
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow">
+      <div className="h-24 rounded bg-gray-200" />
+      <p className="mt-2 text-center text-sm font-medium text-gray-700">
+        {name}
+      </p>
+    </div>
+  );
+}
+
+export default FlagCard;

--- a/src/components/FlagGrid.tsx
+++ b/src/components/FlagGrid.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import FlagCard from "./FlagCard";
+
+const placeholderFlags = [
+  { id: 1, name: "Rainbow" },
+  { id: 2, name: "Transgender" },
+  { id: 3, name: "Bisexual" },
+  { id: 4, name: "Asexual" },
+  { id: 5, name: "Pansexual" },
+  { id: 6, name: "Non-binary" },
+];
+
+function FlagGrid() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {placeholderFlags.map((flag) => (
+        <FlagCard key={flag.id} name={flag.name} />
+      ))}
+    </div>
+  );
+}
+
+export default FlagGrid;


### PR DESCRIPTION
## Summary
- display placeholder flags in a responsive grid
- update Babel configuration to handle TypeScript
- include a simple test for FlagGrid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685844b1e300832488bd5fafbd5fe486