### PR TITLE
Enhance flag cards and layout

### DIFF
--- a/public/flags/asexual.svg
+++ b/public/flags/asexual.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='300' height='160'>
+  <rect width='300' height='40' y='0' fill='#000000'/>
+  <rect width='300' height='40' y='40' fill='#A3A3A3'/>
+  <rect width='300' height='40' y='80' fill='#FFFFFF'/>
+  <rect width='300' height='40' y='120' fill='#800080'/>
+</svg>

--- a/public/flags/bisexual.svg
+++ b/public/flags/bisexual.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='300' height='150'>
+  <rect width='300' height='60' y='0' fill='#D60270'/>
+  <rect width='300' height='30' y='60' fill='#9B4F96'/>
+  <rect width='300' height='60' y='90' fill='#0038A8'/>
+</svg>

--- a/public/flags/non-binary.svg
+++ b/public/flags/non-binary.svg
@@ -1,0 +1,6 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='300' height='160'>
+  <rect width='300' height='40' y='0' fill='#FFF433'/>
+  <rect width='300' height='40' y='40' fill='#FFFFFF'/>
+  <rect width='300' height='40' y='80' fill='#9B59D0'/>
+  <rect width='300' height='40' y='120' fill='#000000'/>
+</svg>

--- a/public/flags/pansexual.svg
+++ b/public/flags/pansexual.svg
@@ -1,0 +1,5 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='300' height='150'>
+  <rect width='300' height='50' y='0' fill='#FF218C'/>
+  <rect width='300' height='50' y='50' fill='#FFD800'/>
+  <rect width='300' height='50' y='100' fill='#21B1FF'/>
+</svg>

--- a/public/flags/rainbow.svg
+++ b/public/flags/rainbow.svg
@@ -1,0 +1,8 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='300' height='180'>
+  <rect width='300' height='30' y='0' fill='#e40303'/>
+  <rect width='300' height='30' y='30' fill='#ff8c00'/>
+  <rect width='300' height='30' y='60' fill='#ffed00'/>
+  <rect width='300' height='30' y='90' fill='#008026'/>
+  <rect width='300' height='30' y='120' fill='#004dff'/>
+  <rect width='300' height='30' y='150' fill='#750787'/>
+</svg>

--- a/public/flags/transgender.svg
+++ b/public/flags/transgender.svg
@@ -1,0 +1,7 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='300' height='150'>
+  <rect width='300' height='30' y='0' fill='#5BCEFA'/>
+  <rect width='300' height='30' y='30' fill='#F5A9B8'/>
+  <rect width='300' height='30' y='60' fill='#FFFFFF'/>
+  <rect width='300' height='30' y='90' fill='#F5A9B8'/>
+  <rect width='300' height='30' y='120' fill='#5BCEFA'/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,11 @@ import FlagGrid from "./components/FlagGrid";
 
 function App() {
   return (
-    <div className="min-h-screen bg-gray-50">
-      <header className="bg-gradient-to-r from-pink-500 to-purple-600 py-4 text-white">
-        <h1 className="text-center text-2xl font-bold">Patchwork Pride</h1>
+    <div className="min-h-screen bg-gradient-to-br from-pink-100 to-indigo-100">
+      <header>
+        <h1 className="mt-8 mb-4 text-center text-4xl font-bold">Patchwork Pride</h1>
       </header>
-      <main className="p-4">
+      <main>
         <FlagGrid />
       </main>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,7 @@ function App() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-pink-100 to-indigo-100">
       <header>
-        <h1 className="mt-8 mb-4 text-center text-4xl font-bold">Patchwork Pride</h1>
+        <h1 className="mt-8 mb-6 text-center text-3xl font-bold">Patchwork Pride</h1>
       </header>
       <main>
         <FlagGrid />

--- a/src/components/FlagCard.tsx
+++ b/src/components/FlagCard.tsx
@@ -2,15 +2,18 @@ import React from "react";
 
 interface FlagCardProps {
   name: string;
+  image: string;
 }
 
-function FlagCard({ name }: FlagCardProps) {
+function FlagCard({ name, image }: FlagCardProps) {
   return (
-    <div className="rounded-lg border bg-white p-4 shadow">
-      <div className="h-24 rounded bg-gray-200" />
-      <p className="mt-2 text-center text-sm font-medium text-gray-700">
-        {name}
-      </p>
+    <div className="overflow-hidden rounded-md border bg-white shadow transition-transform duration-200 hover:scale-105">
+      <img
+        src={image}
+        alt={`${name} flag`}
+        className="h-40 w-full rounded-t-md object-cover"
+      />
+      <p className="p-4 text-center text-sm font-medium text-gray-700">{name}</p>
     </div>
   );
 }

--- a/src/components/FlagCard.tsx
+++ b/src/components/FlagCard.tsx
@@ -7,13 +7,13 @@ interface FlagCardProps {
 
 function FlagCard({ name, image }: FlagCardProps) {
   return (
-    <div className="relative overflow-hidden rounded-lg bg-white shadow transition-transform duration-200 hover:z-10 hover:scale-105">
+    <div className="overflow-hidden rounded-md bg-white p-4 shadow transition-transform duration-200 hover:z-10 hover:scale-105">
       <img
         src={image}
         alt={`${name} flag`}
-        className="h-32 w-full object-cover"
+        className="mb-2 h-32 w-full rounded-md object-cover"
       />
-      <p className="p-3 text-center text-sm font-medium text-gray-700">{name}</p>
+      <p className="text-center text-sm font-medium text-gray-700">{name}</p>
     </div>
   );
 }

--- a/src/components/FlagCard.tsx
+++ b/src/components/FlagCard.tsx
@@ -7,13 +7,13 @@ interface FlagCardProps {
 
 function FlagCard({ name, image }: FlagCardProps) {
   return (
-    <div className="overflow-hidden rounded-md border bg-white shadow transition-transform duration-200 hover:scale-105">
+    <div className="relative overflow-hidden rounded-lg bg-white shadow transition-transform duration-200 hover:z-10 hover:scale-105">
       <img
         src={image}
         alt={`${name} flag`}
-        className="h-40 w-full rounded-t-md object-cover"
+        className="h-32 w-full object-cover"
       />
-      <p className="p-4 text-center text-sm font-medium text-gray-700">{name}</p>
+      <p className="p-3 text-center text-sm font-medium text-gray-700">{name}</p>
     </div>
   );
 }

--- a/src/components/FlagGrid.tsx
+++ b/src/components/FlagGrid.tsx
@@ -12,7 +12,7 @@ const placeholderFlags = [
 
 function FlagGrid() {
   return (
-    <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 p-6 sm:grid-cols-2 md:grid-cols-3">
+    <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 px-6 py-8 md:grid-cols-2 lg:grid-cols-3">
       {placeholderFlags.map((flag) => (
         <FlagCard key={flag.id} name={flag.name} image={flag.image} />
       ))}

--- a/src/components/FlagGrid.tsx
+++ b/src/components/FlagGrid.tsx
@@ -2,19 +2,19 @@ import React from "react";
 import FlagCard from "./FlagCard";
 
 const placeholderFlags = [
-  { id: 1, name: "Rainbow" },
-  { id: 2, name: "Transgender" },
-  { id: 3, name: "Bisexual" },
-  { id: 4, name: "Asexual" },
-  { id: 5, name: "Pansexual" },
-  { id: 6, name: "Non-binary" },
+  { id: 1, name: "Rainbow", image: "/flags/rainbow.svg" },
+  { id: 2, name: "Transgender", image: "/flags/transgender.svg" },
+  { id: 3, name: "Bisexual", image: "/flags/bisexual.svg" },
+  { id: 4, name: "Asexual", image: "/flags/asexual.svg" },
+  { id: 5, name: "Pansexual", image: "/flags/pansexual.svg" },
+  { id: 6, name: "Non-binary", image: "/flags/non-binary.svg" },
 ];
 
 function FlagGrid() {
   return (
-    <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+    <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 p-4 sm:grid-cols-2 md:grid-cols-3">
       {placeholderFlags.map((flag) => (
-        <FlagCard key={flag.id} name={flag.name} />
+        <FlagCard key={flag.id} name={flag.name} image={flag.image} />
       ))}
     </div>
   );

--- a/src/components/FlagGrid.tsx
+++ b/src/components/FlagGrid.tsx
@@ -12,7 +12,7 @@ const placeholderFlags = [
 
 function FlagGrid() {
   return (
-    <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 p-4 sm:grid-cols-2 md:grid-cols-3">
+    <div className="mx-auto grid max-w-4xl grid-cols-1 gap-6 p-6 sm:grid-cols-2 md:grid-cols-3">
       {placeholderFlags.map((flag) => (
         <FlagCard key={flag.id} name={flag.name} image={flag.image} />
       ))}


### PR DESCRIPTION
## Summary
- add simple SVG images for each flag
- display images in `FlagCard` with hover effect
- improve grid responsiveness and centering
- use a soft gradient background and larger centered heading

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685de0d30e808324b102db951c41e6dd