### PR TITLE
Responsive patchwork grid

### DIFF
--- a/src/components/PatchworkBackground.tsx
+++ b/src/components/PatchworkBackground.tsx
@@ -13,42 +13,48 @@ interface Patch {
 
 const patches: Patch[] = [
   {
-    class: 'md:col-start-1 md:col-span-3 md:row-start-1 md:row-span-2',
+    class:
+      'col-span-3 row-span-2 md:col-start-1 md:col-span-3 md:row-start-1 md:row-span-2',
     color: 'bg-coral',
     border: 'border-coral',
     name: 'Rainbow',
     image: '/flags/rainbow.svg',
   },
   {
-    class: 'md:col-start-4 md:col-span-3 md:row-start-1 md:row-span-3',
+    class:
+      'col-span-3 row-span-3 md:col-start-4 md:col-span-3 md:row-start-1 md:row-span-3',
     color: 'bg-teal',
     border: 'border-teal',
     name: 'Transgender',
     image: '/flags/transgender.svg',
   },
   {
-    class: 'md:col-start-1 md:col-span-2 md:row-start-3 md:row-span-2',
+    class:
+      'col-span-2 row-span-2 md:col-start-1 md:col-span-2 md:row-start-3 md:row-span-2',
     color: 'bg-periwinkle',
     border: 'border-periwinkle',
     name: 'Bisexual',
     image: '/flags/bisexual.svg',
   },
   {
-    class: 'md:col-start-3 md:col-span-2 md:row-start-3 md:row-span-1',
+    class:
+      'col-span-2 row-span-1 md:col-start-3 md:col-span-2 md:row-start-3 md:row-span-1',
     color: 'bg-mustard',
     border: 'border-mustard',
     name: 'Asexual',
     image: '/flags/asexual.svg',
   },
   {
-    class: 'md:col-start-3 md:col-span-3 md:row-start-4 md:row-span-2',
+    class:
+      'col-span-3 row-span-2 md:col-start-3 md:col-span-3 md:row-start-4 md:row-span-2',
     color: 'bg-offwhite',
     border: 'border-periwinkle',
     name: 'Pansexual',
     image: '/flags/pansexual.svg',
   },
   {
-    class: 'md:col-start-6 md:col-span-1 md:row-start-4 md:row-span-2',
+    class:
+      'col-span-1 row-span-2 md:col-start-6 md:col-span-1 md:row-start-4 md:row-span-2',
     color: 'bg-coral',
     border: 'border-coral',
     name: 'Non-binary',
@@ -61,12 +67,12 @@ function PatchworkBackground() {
 
   return (
     <div
-      className="grid grid-cols-[repeat(auto-fit,_minmax(160px,_1fr))] auto-rows-fr gap-2 p-2 sm:p-4 md:p-2 md:grid-cols-6 md:grid-rows-6 md:auto-rows-auto"
+      className="grid auto-flow-dense grid-cols-[repeat(auto-fit,_minmax(160px,_1fr))] auto-rows-[minmax(120px,_1fr)] gap-2 p-2 sm:gap-3 sm:p-4 md:p-2 md:auto-flow-row md:grid-cols-6 md:grid-rows-6 md:auto-rows-auto"
     >
       {patches.map((patch) => (
         <div
           key={patch.name}
-          className={`${patch.class} flex items-center justify-center rounded-lg border border-dashed ${patch.border} ${patch.color} p-2 sm:p-3 md:p-2`}
+          className={`${patch.class} flex items-center justify-center rounded-lg border border-dashed ${patch.border} ${patch.color} p-2 sm:p-3 md:p-2 min-h-[120px]`}
         >
           <FlagCard
             name={patch.name}

--- a/src/components/PatchworkBackground.tsx
+++ b/src/components/PatchworkBackground.tsx
@@ -13,42 +13,42 @@ interface Patch {
 
 const patches: Patch[] = [
   {
-    class: 'col-start-1 col-span-3 row-start-1 row-span-2',
+    class: 'md:col-start-1 md:col-span-3 md:row-start-1 md:row-span-2',
     color: 'bg-coral',
     border: 'border-coral',
     name: 'Rainbow',
     image: '/flags/rainbow.svg',
   },
   {
-    class: 'col-start-4 col-span-3 row-start-1 row-span-3',
+    class: 'md:col-start-4 md:col-span-3 md:row-start-1 md:row-span-3',
     color: 'bg-teal',
     border: 'border-teal',
     name: 'Transgender',
     image: '/flags/transgender.svg',
   },
   {
-    class: 'col-start-1 col-span-2 row-start-3 row-span-2',
+    class: 'md:col-start-1 md:col-span-2 md:row-start-3 md:row-span-2',
     color: 'bg-periwinkle',
     border: 'border-periwinkle',
     name: 'Bisexual',
     image: '/flags/bisexual.svg',
   },
   {
-    class: 'col-start-3 col-span-2 row-start-3 row-span-1',
+    class: 'md:col-start-3 md:col-span-2 md:row-start-3 md:row-span-1',
     color: 'bg-mustard',
     border: 'border-mustard',
     name: 'Asexual',
     image: '/flags/asexual.svg',
   },
   {
-    class: 'col-start-3 col-span-3 row-start-4 row-span-2',
+    class: 'md:col-start-3 md:col-span-3 md:row-start-4 md:row-span-2',
     color: 'bg-offwhite',
     border: 'border-periwinkle',
     name: 'Pansexual',
     image: '/flags/pansexual.svg',
   },
   {
-    class: 'col-start-6 col-span-1 row-start-4 row-span-2',
+    class: 'md:col-start-6 md:col-span-1 md:row-start-4 md:row-span-2',
     color: 'bg-coral',
     border: 'border-coral',
     name: 'Non-binary',
@@ -60,11 +60,13 @@ function PatchworkBackground() {
   const [selected, setSelected] = useState<Patch | null>(null)
 
   return (
-    <div className="grid grid-cols-6 grid-rows-6 gap-1 p-2 md:gap-2">
+    <div
+      className="grid grid-cols-[repeat(auto-fit,_minmax(160px,_1fr))] auto-rows-fr gap-2 p-2 sm:p-4 md:p-2 md:grid-cols-6 md:grid-rows-6 md:auto-rows-auto"
+    >
       {patches.map((patch) => (
         <div
           key={patch.name}
-          className={`${patch.class} flex items-center justify-center rounded-lg border border-dashed ${patch.border} ${patch.color} p-2`}
+          className={`${patch.class} flex items-center justify-center rounded-lg border border-dashed ${patch.border} ${patch.color} p-2 sm:p-3 md:p-2`}
         >
           <FlagCard
             name={patch.name}


### PR DESCRIPTION
## Summary
- make patch grid responsive with `auto-fit` and `minmax`
- keep patch layout on larger screens

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6861aee17e6c832491559314ae454b84